### PR TITLE
Document pre-requisites for development

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,31 @@ The newer methods in `java.nio.file.Files` replaced the need for some of communi
 + List<String> lines = Files.readAllLines(file.toPath());
 ```
 
+# Setup
+
+1. Install JDK 17 for building this project. We recommend [Eclipse Adoptium](https://adoptium.net/)
+
+1. Install [Semgrep](https://semgrep.dev/) CLI. See
+   [here](https://semgrep.dev/docs/getting-started/#installing-and-running-semgrep-locally)
+   for instructions. It can usually be done via `pip`:
+   ```shell
+   pip install semgrep
+   ```
+
+If your Python library paths contain your home directory as a root folder (i.e.
+due to the use of the `$HOME` environment variable), you may need to manually
+set up your `PYTHONPATH` for tests:
+
+```shell
+PYTHONPATH=$HOME/<subpath-to-python-libs-folder> ./gradlew check
+```
+
+You can check your python paths with:
+
+```shell
+python -m site
+```
+
 # Testing
 
 ```bash


### PR DESCRIPTION
The `README` doesn't explicitly tell users about what other infrastructure they will need to successfully run the codemod (Python, Semgrep, etc). This change fixes that and closes #17 .